### PR TITLE
Fix body parsing in case response is not a json.

### DIFF
--- a/lib/antecons.js
+++ b/lib/antecons.js
@@ -66,7 +66,12 @@ Antecons.prototype._request = function(endpoint, method, data, callback) {
 
     resp.on('end', function() {
       self.log('Data: ' + respBody);
-      var result = JSON.parse(respBody);
+      try {
+        var result = JSON.parse(respBody);
+      } catch(e) {
+        self.log('Parsing error: ' + e);
+        return callback ? callback(e) : null;
+      }
       if (callback) {
         callback(null, result);
       }


### PR DESCRIPTION
It can happen for 500 errors, for example.
