### PR TITLE
Fix true url parameter after false

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -62,19 +62,13 @@ class Resource {
       // Run through the urlparams and match them with the method arguments.
       for (let i = 0; i < urlParams.length; i++) {
         const param = urlParams[i];
-        if (args[0]) {
-          urlData[param] = args.shift();
-        }
-        else {
-          urlData[param] = '';
-        }
+        urlData[param] = args[i] || '';
       }
 
       const requestCallback = (err, resp) => {
         if (err) {
           deferred.reject(err);
-        }
-        else {
+        } else {
           deferred.resolve(resp);
         }
       };

--- a/test/suggestion.js
+++ b/test/suggestion.js
@@ -46,4 +46,13 @@ describe('Suggestion', () => {
         mock.done();
       });
   });
+
+  it('should support a false url param before a true one', () => {
+    const mock = nock('https://api.antecons.net')
+      .get('/datasource/test/suggestion?for=product&for_id=beer&limit=10&full=&strong_only=true')
+      .reply(201, [suggestion]);
+
+    return antecons.suggestion.list('test', 'product', 'beer', 10, false, true)
+      .then(res => mock.done());
+  });
 });


### PR DESCRIPTION
This commit fixes a bug where a url param was not shifted in the
url param arguments array if the value was falsy.
